### PR TITLE
Add shotgun blind-fire recoil pulse

### DIFF
--- a/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
+++ b/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
@@ -178,16 +178,17 @@ Wall Bounce - 					- Bounce walls when running.
 	const string AUTO_X_SPAM        = "AutoSpam L1";     // modName_idx = 14
         const string AUTO_COVER_EXIT    = "Cover Exit";      // modName_idx = 15
 		const string ENHANCED_STICK     = "Stick Xcel";      // modName_idx = 16
-		const string POP_SHOT           = "Pop Shot";        // modName_idx = 17
+                const string POP_SHOT           = "Pop Shot";        // modName_idx = 17
+                const string SHOTGUN_RECOIL     = "ShotgunAR";       // modName_idx = 18
 
 // Index to find Mod Name string - switchable in game with left/right in ModMenu 
 	int modName_idx;
 
 // modName # of the last Mod Name string - Used for cycle modName_idx
-	define LAST_MODNAME_STRING = 17;
+        define LAST_MODNAME_STRING = 18;
 
 // # of the last modName_idx that has a value that can be edited
-	define LAST_EDITABLE_STRING = 17;
+        define LAST_EDITABLE_STRING = 18;
 	
 // 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 
 
@@ -225,6 +226,8 @@ Wall Bounce - 					- Bounce walls when running.
         const string AUTORELOAD_HOLD    = "AR Hold ms";      // valName_idx = 17
         // AutoRun L3 toggle setting
         const string AUTORUN_L3_TOGGLE  = "L3 Toggle";       // valName_idx = 18
+        const string SHOTGUN_VERTICAL   = "SG Vertical";     // valName_idx = 20
+        const string SHOTGUN_DURATION   = "SG Dur ms";       // valName_idx = 21
 
         // Text for special display cases
         const string CLASSIC_STR        = "Classic";
@@ -235,7 +238,7 @@ Wall Bounce - 					- Bounce walls when running.
 	int valName_idx;
 	int prev_valName_idx;
 	
-    define AMOUNT_OF_VALNAME_IDX = 19;
+    define AMOUNT_OF_VALNAME_IDX = 21;
 
 // 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 
 
@@ -323,6 +326,15 @@ int easyPing_ads_active;        // TRUE while ADS is held for Easy Ping
     // --- Pop Shot (R2 auto-hold L2) ---
     int toggle_popShot[3];         // Per-profile toggle
     int popShot_hold_ms;           // Global L2 hold ms
+
+    // --- Shotgun Recoil Pulse ---
+    int toggle_shotgunRecoil[3];   // Per-profile toggle
+    int shotgun_recoil_vertical[3];// Per-profile vertical strength
+    int shotgun_recoil_time_ms;    // Global pulse duration (ms)
+    int shotgun_recoil_timer;      // Remaining ms for the active pulse combo
+    int shotgun_recoil_strength;   // Signed strength applied during the combo
+    int shotgun_recoil_step;       // Wait slice for combo looping
+    int shotgun_recoil_output;     // Temporary output value for the combo
     
     // --- AutoReload Hold-Time Gate ---
     int autoReload_hold_ms;        // Global minimum hold time for R2 (ms)
@@ -383,6 +395,10 @@ define MASK_AUTORUN_L3  = 32768; // bit 15
 define MASK_COVEREXIT_MODE_P1 = 65536;   // bit 16
 define MASK_COVEREXIT_MODE_P2 = 131072;  // bit 17
 define MASK_COVEREXIT_MODE_P3 = 262144;  // bit 18
+// Shotgun recoil pulse toggles
+define MASK_SHOTGUN_P1 = 524288;   // bit 19
+define MASK_SHOTGUN_P2 = 1048576;  // bit 20
+define MASK_SHOTGUN_P3 = 2097152;  // bit 21
 // Migration flag bits
 define MIG_FLAG_STICK_RESET      = 1;
 define MIG_FLAG_EASYPING_DEFAULT = 2;
@@ -508,14 +524,17 @@ data(
  
 init{
 // One-time migration: set new default toggles and P3 rapidfire, then mark as migrated
-    migrated = get_pvar(SPVAR_62, 0, 1, 0);
+    int shotgun_pack = get_pvar(SPVAR_62, 0, 33554431, 0);
+    migrated = shotgun_pack & 1;
     if(migrated == 0) {
         packed_toggles = (MASK_SPAM_P1 | MASK_COVEREXIT_P1 |
                           MASK_SPAM_P2 | MASK_COVEREXIT_P2 |
                           MASK_SPAM_P3 | MASK_COVEREXIT_P3);
         set_pvar(SPVAR_56, packed_toggles);
         set_pvar(SPVAR_33, 1); // Rapid Fire default ON for Profile 3
-        set_pvar(SPVAR_62, 1); // Migration complete
+        shotgun_pack = 1;
+        set_pvar(SPVAR_62, shotgun_pack); // Migration complete
+        migrated = 1;
     }
 
     // One-time migration v2: bump Spam Speed default from 40 -> 80 only if still at old default
@@ -547,6 +566,20 @@ init{
         if(perfectreload_time[2] == 0 || perfectreload_time[2] == 100 || perfectreload_time[2] == 200) set_pvar(SPVAR_46, 480);
 
         set_pvar(SPVAR_63, 2);
+    }
+    // Load stored shotgun recoil vertical values (packed in SPVAR_62 bits 1-24)
+    shotgun_pack = get_pvar(SPVAR_62, 0, 33554431, shotgun_pack);
+    if(shotgun_pack <= 1) {
+        shotgun_recoil_vertical[0] = 0;
+        shotgun_recoil_vertical[1] = 0;
+        shotgun_recoil_vertical[2] = 0;
+    } else {
+        shotgun_recoil_vertical[0] = (shotgun_pack >> 1) & 0xFF;
+        shotgun_recoil_vertical[1] = (shotgun_pack >> 9) & 0xFF;
+        shotgun_recoil_vertical[2] = (shotgun_pack >> 17) & 0xFF;
+        if(shotgun_recoil_vertical[0] > 99) shotgun_recoil_vertical[0] = 99;
+        if(shotgun_recoil_vertical[1] > 99) shotgun_recoil_vertical[1] = 99;
+        if(shotgun_recoil_vertical[2] > 99) shotgun_recoil_vertical[2] = 99;
     }
 // Profile 1
 	// Toggles                                                  // Values
@@ -607,7 +640,7 @@ init{
     packed_toggles = get_pvar(
         SPVAR_56,
         0,
-        524287,
+        4194303,
         (MASK_SPAM_P1 | MASK_COVEREXIT_P1 |
          MASK_SPAM_P2 | MASK_COVEREXIT_P2 |
          MASK_SPAM_P3 | MASK_COVEREXIT_P3 |
@@ -659,6 +692,7 @@ init{
     if(packed_toggles & MASK_COVEREXIT_MODE_P1) { autoCoverExit_mode[0] = 1; } else { autoCoverExit_mode[0] = 0; }
     if(packed_toggles & MASK_SPAMMODE_P1) { autoXSpam_mode[0] = 1; } else { autoXSpam_mode[0] = 0; }
     if(packed_toggles & MASK_POPSHOT_P1) { toggle_popShot[0] = TRUE; } else { toggle_popShot[0] = FALSE; }
+    if(packed_toggles & MASK_SHOTGUN_P1) { toggle_shotgunRecoil[0] = TRUE; } else { toggle_shotgunRecoil[0] = FALSE; }
 
     // --- Unpack Profile 2 Toggles ---
     if(packed_toggles & MASK_SPAM_P2) { toggle_autoXSpam[1] = TRUE; } else { toggle_autoXSpam[1] = FALSE; }
@@ -667,6 +701,7 @@ init{
     if(packed_toggles & MASK_COVEREXIT_MODE_P2) { autoCoverExit_mode[1] = 1; } else { autoCoverExit_mode[1] = 0; }
     if(packed_toggles & MASK_SPAMMODE_P2) { autoXSpam_mode[1] = 1; } else { autoXSpam_mode[1] = 0; }
     if(packed_toggles & MASK_POPSHOT_P2) { toggle_popShot[1] = TRUE; } else { toggle_popShot[1] = FALSE; }
+    if(packed_toggles & MASK_SHOTGUN_P2) { toggle_shotgunRecoil[1] = TRUE; } else { toggle_shotgunRecoil[1] = FALSE; }
 
     // --- Unpack Profile 3 Toggles ---
     if(packed_toggles & MASK_SPAM_P3) { toggle_autoXSpam[2] = TRUE; } else { toggle_autoXSpam[2] = FALSE; }
@@ -675,6 +710,7 @@ init{
     if(packed_toggles & MASK_COVEREXIT_MODE_P3) { autoCoverExit_mode[2] = 1; } else { autoCoverExit_mode[2] = 0; }
     if(packed_toggles & MASK_SPAMMODE_P3) { autoXSpam_mode[2] = 1; } else { autoXSpam_mode[2] = 0; }
     if(packed_toggles & MASK_POPSHOT_P3) { toggle_popShot[2] = TRUE; } else { toggle_popShot[2] = FALSE; }
+    if(packed_toggles & MASK_SHOTGUN_P3) { toggle_shotgunRecoil[2] = TRUE; } else { toggle_shotgunRecoil[2] = FALSE; }
     // --- Unpack Global: AutoRun L3 Toggle ---
     if(packed_toggles & MASK_AUTORUN_L3) { autorun_l3_toggle_enabled = TRUE; } else { autorun_l3_toggle_enabled = FALSE; }
 
@@ -684,7 +720,18 @@ init{
     autoCoverExit_duration   = get_pvar(SPVAR_59, 50, 500, 150);
     autoCoverExit_cooldown   = get_pvar(SPVAR_60, 100, 2000, 500);
     enhancedStick_threshold  = get_pvar(SPVAR_61, 10, 95, 30);
-    popShot_hold_ms          = get_pvar(SPVAR_64, 10, 500, 80);
+    int popshot_pack = get_pvar(SPVAR_64, 0, 262143, (120 << 9) | 80);
+    if(popshot_pack <= 500) {
+        popShot_hold_ms = popshot_pack;
+        shotgun_recoil_time_ms = 120;
+    } else {
+        popShot_hold_ms = popshot_pack & 0x1FF;
+        shotgun_recoil_time_ms = (popshot_pack >> 9) & 0x1FF;
+    }
+    if(popShot_hold_ms < 10) popShot_hold_ms = 10;
+    if(popShot_hold_ms > 500) popShot_hold_ms = 500;
+    if(shotgun_recoil_time_ms < 10) shotgun_recoil_time_ms = 120;
+    if(shotgun_recoil_time_ms > 500) shotgun_recoil_time_ms = 500;
     // AutoReload hold-time (default 1000ms)
     // Store AutoReload hold time in SPVAR_63 to avoid exceeding SPVAR range.
     // Read raw first to handle legacy migration values (0..2), then clamp to range.
@@ -909,6 +956,7 @@ if(!KillSwitch)
 				antirecoil_horizontal[profile_idx] = edit_val( 1 , antirecoil_horizontal[profile_idx],  99, 99 , 1 , 10   );
 				rate_of_fire[profile_idx]          = edit_val( 2 , rate_of_fire[profile_idx]         ,  0 , 25 , 1 , 10   );  // 25 rounds/s max
                 perfectreload_time [profile_idx]   = edit_val( 9 , perfectreload_time [profile_idx]   ,  0  , 5000 , 10 , 50     );
+                shotgun_recoil_vertical[profile_idx] = edit_val( 20, shotgun_recoil_vertical[profile_idx], 0 , 99 , 1 , 10   );
 			// Mods that have same value on every Profiles
 			
 			  //val_I_want_to_edit = edit_val( corresponding valName_idx , val_I_want_to_edit, range min , range max );
@@ -926,6 +974,7 @@ if(!KillSwitch)
                 autoCoverExit_mode[profile_idx] = edit_val( 19, autoCoverExit_mode[profile_idx], 0, 1, 1, 1);
                 enhancedStick_threshold     = edit_val( 15, enhancedStick_threshold, 10, 95, 5, 10);
                 popShot_hold_ms             = edit_val( 16, popShot_hold_ms, 10, 500, 10, 50);
+                shotgun_recoil_time_ms      = edit_val( 21, shotgun_recoil_time_ms, 10, 500, 5, 25);
                 autoReload_hold_ms          = edit_val( 17, autoReload_hold_ms, 100, 5000, 10, 100);
                 autorun_l3_toggle_enabled   = edit_val( 18, autorun_l3_toggle_enabled, 0, 1, 1, 1);
 			}
@@ -959,7 +1008,8 @@ if(!KillSwitch)
 					if(modName_idx == 5) vals_available( 8 , 8  );// Custom Sense
                     if(modName_idx == 6) vals_available( 9 , 9  );//Perfect Reload
                     if(modName_idx == 17) vals_available( 16, 16 );//Pop Shot
-					if(modName_idx == 14) vals_available( 10, 11 );// Auto X Spam (Mode, Speed)
+                    if(modName_idx == 18) vals_available( 20, 21 );//Shotgun Recoil
+                    if(modName_idx == 14) vals_available( 10, 11 );// Auto X Spam (Mode, Speed)
 					if(modName_idx == 15) vals_available( 12, 19 );// Auto Cover Exit (Delay, Duration, Cooldown, Mode)
                 if(modName_idx == 16) vals_available( 15, 15 );// Enhanced Stick (Threshold)
                 if(modName_idx == 7)  vals_available( 17, 17 );// AutoReload (Hold ms)
@@ -1040,7 +1090,8 @@ if(!KillSwitch)
                 toggle_autoCoverExit[profile_idx] = toggle( 15, toggle_autoCoverExit[profile_idx] );
                 toggle_enhancedStick[profile_idx] = toggle( 16, toggle_enhancedStick[profile_idx] );
                 toggle_popShot[profile_idx]       = toggle( 17, toggle_popShot[profile_idx] );
-		} // if NOT ModEdit BUT if ModMenu end
+                toggle_shotgunRecoil[profile_idx] = toggle( 18, toggle_shotgunRecoil[profile_idx] );
+                } // if NOT ModEdit BUT if ModMenu end
 		
 	// If ModMenu AND ModEdit
 		if(event_press(PS4_CIRCLE))
@@ -1478,6 +1529,16 @@ if(toggle_turboMelee [profile_idx] == 1) {
         if(toggle_popShot[profile_idx] && event_press(PS4_R2)) {
             combo_run(POP_SHOT_L2_HOLD);
         }
+        if(toggle_shotgunRecoil[profile_idx] && !get_val(PS4_L2) && event_press(PS4_R2)) {
+            if(shotgun_recoil_vertical[profile_idx] > 0 && shotgun_recoil_time_ms > 0) {
+                combo_stop(SHOTGUN_RECOIL);
+                shotgun_recoil_timer = shotgun_recoil_time_ms;
+                shotgun_recoil_strength = shotgun_recoil_vertical[profile_idx] * invert;
+                if(shotgun_recoil_strength > 100) shotgun_recoil_strength = 100;
+                if(shotgun_recoil_strength < -100) shotgun_recoil_strength = -100;
+                combo_run(SHOTGUN_RECOIL);
+            }
+        }
     }
 
   /*— ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌ — ◌
@@ -1559,6 +1620,7 @@ if(toggle_turboMelee [profile_idx] == 1) {
 			display_edit( 1 , center_x(sizeof(ANTIRECOIL_HORIZONTAL) - 1, OLED_FONT_MEDIUM_WIDTH) , ANTIRECOIL_HORIZONTAL[0] , antirecoil_horizontal[profile_idx] );
 			display_edit( 2 , center_x(sizeof(RATE_OF_FIRE) - 1 , OLED_FONT_MEDIUM_WIDTH)         , RATE_OF_FIRE[0]          , rate_of_fire[profile_idx]          );
                 display_edit( 9 , center_x(sizeof(PERFECTRELOAD_TIME) - 1 , OLED_FONT_MEDIUM_WIDTH)   , PERFECTRELOAD_TIME[0]    , perfectreload_time[profile_idx]  );
+                display_edit( 20, center_x(sizeof(SHOTGUN_VERTICAL) - 1 , OLED_FONT_MEDIUM_WIDTH)    , SHOTGUN_VERTICAL[0]     , shotgun_recoil_vertical[profile_idx] );
 			
 				// Mods that have same value on every Profile
 				display_edit( 3 , center_x(sizeof(BURSTFIRE_HOLD) - 1, OLED_FONT_MEDIUM_WIDTH)    , BURSTFIRE_HOLD[0]    , burstfire_hold    );
@@ -1592,6 +1654,7 @@ if(toggle_turboMelee [profile_idx] == 1) {
                     }
                     display_edit( 15, center_x(sizeof(STICK_THRESHOLD) - 1, OLED_FONT_MEDIUM_WIDTH)   , STICK_THRESHOLD[0]   , enhancedStick_threshold           );
                     display_edit( 17, center_x(sizeof(AUTORELOAD_HOLD) - 1, OLED_FONT_MEDIUM_WIDTH)   , AUTORELOAD_HOLD[0]   , autoReload_hold_ms                );
+                    display_edit( 21, center_x(sizeof(SHOTGUN_DURATION) - 1, OLED_FONT_MEDIUM_WIDTH)  , SHOTGUN_DURATION[0]  , shotgun_recoil_time_ms            );
                     // Special-case: Show L3 Toggle as ON/OFF text instead of 0/1
                     if(valName_idx == 18) {
                         printf(center_x(sizeof(AUTORUN_L3_TOGGLE) - 1, OLED_FONT_MEDIUM_WIDTH), 0, OLED_FONT_MEDIUM, OLED_WHITE, AUTORUN_L3_TOGGLE[0]);
@@ -1627,10 +1690,11 @@ if(toggle_turboMelee [profile_idx] == 1) {
                 display_mod( 15 ,  center_x(sizeof(AUTO_COVER_EXIT) - 1, OLED_FONT_MEDIUM_WIDTH), AUTO_COVER_EXIT[0] , toggle_autoCoverExit[profile_idx] );
                 display_mod( 16 ,  center_x(sizeof(ENHANCED_STICK) - 1, OLED_FONT_MEDIUM_WIDTH) , ENHANCED_STICK[0]  , toggle_enhancedStick[profile_idx] );
                 display_mod( 17 ,  center_x(sizeof(POP_SHOT) - 1, OLED_FONT_MEDIUM_WIDTH)       , POP_SHOT[0]        , toggle_popShot[profile_idx] );
-		}
+                display_mod( 18 ,  center_x(sizeof(SHOTGUN_RECOIL) - 1, OLED_FONT_MEDIUM_WIDTH) , SHOTGUN_RECOIL[0]  , toggle_shotgunRecoil[profile_idx] );
+                }
 		
 	// Display Profile only on mods that may have a different value depending on the Profile
-		if(modName_idx < AMOUNT_OF_MULTI_TOGGLE)  // idx from 0 to 4 are mods that can have different values depending the active Profile
+                if(modName_idx < AMOUNT_OF_MULTI_TOGGLE || modName_idx == 17 || modName_idx == 18)  // idx from 0 to 4 are mods that can have different values depending the active Profile
 		{
 			if(profile_idx == 0) // profile_idx = profile_idx = Profile
     			//printf(center_x(sizeof(PROFILE_1) - 1, OLED_FONT_SMALL_WIDTH),23,OLED_FONT_SMALL,OLED_WHITE,PROFILE_1[0]); // print Profile 1
@@ -1743,7 +1807,7 @@ combo SAVE {
  
 combo ANTIRECOIL {
 // Vertical
-    AntirecoilVertical = get_val(PS4_RY) + (VALUES[profile_idx][0] + antirecoil_vertical[profile_idx]);  
+    AntirecoilVertical = get_val(PS4_RY) + (VALUES[profile_idx][0] + antirecoil_vertical[profile_idx]);
     if(AntirecoilVertical > 100) AntirecoilVertical = 100;
     if(abs(get_val(PS4_RY)) < abs(VALUES[profile_idx][0] + antirecoil_vertical[profile_idx]) + 5)
     set_val(PS4_RY, (AntirecoilVertical * invert));
@@ -1752,6 +1816,23 @@ combo ANTIRECOIL {
     if(AntirecoilHorizontal > 100) AntirecoilHorizontal = 100;
     if(abs(get_val(PS4_RX)) < abs(VALUES[profile_idx][1] + antirecoil_horizontal[profile_idx]) + 5)
     set_val(PS4_RX, AntirecoilHorizontal);
+}
+
+combo SHOTGUN_RECOIL {
+    if(shotgun_recoil_timer <= 0) {
+        shotgun_recoil_timer = 0;
+    } else {
+        shotgun_recoil_step = shotgun_recoil_timer;
+        if(shotgun_recoil_step > 10) shotgun_recoil_step = 10;
+        if(shotgun_recoil_step <= 0) shotgun_recoil_step = 1;
+        shotgun_recoil_output = get_val(PS4_RY) + shotgun_recoil_strength;
+        if(shotgun_recoil_output > 100) shotgun_recoil_output = 100;
+        if(shotgun_recoil_output < -100) shotgun_recoil_output = -100;
+        set_val(PS4_RY, shotgun_recoil_output);
+        wait(shotgun_recoil_step);
+        shotgun_recoil_timer -= shotgun_recoil_step;
+        if(shotgun_recoil_timer > 0) combo_restart(SHOTGUN_RECOIL);
+    }
 }
  
 // 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 
@@ -2340,6 +2421,7 @@ if(toggle_enhancedStick[0])  packed_toggles |= MASK_STICK_P1;
 if(autoCoverExit_mode[0])    packed_toggles |= MASK_COVEREXIT_MODE_P1;
 if(autoXSpam_mode[0])        packed_toggles |= MASK_SPAMMODE_P1;
 if(toggle_popShot[0])        packed_toggles |= MASK_POPSHOT_P1;
+if(toggle_shotgunRecoil[0]) packed_toggles |= MASK_SHOTGUN_P1;
 // Pack Profile 2
 if(toggle_autoXSpam[1])      packed_toggles |= MASK_SPAM_P2;
 if(toggle_autoCoverExit[1])  packed_toggles |= MASK_COVEREXIT_P2;
@@ -2347,6 +2429,7 @@ if(toggle_enhancedStick[1])  packed_toggles |= MASK_STICK_P2;
 if(autoCoverExit_mode[1])    packed_toggles |= MASK_COVEREXIT_MODE_P2;
 if(autoXSpam_mode[1])        packed_toggles |= MASK_SPAMMODE_P2;
 if(toggle_popShot[1])        packed_toggles |= MASK_POPSHOT_P2;
+if(toggle_shotgunRecoil[1]) packed_toggles |= MASK_SHOTGUN_P2;
 // Pack Profile 3
 if(toggle_autoXSpam[2])      packed_toggles |= MASK_SPAM_P3;
 if(toggle_autoCoverExit[2])  packed_toggles |= MASK_COVEREXIT_P3;
@@ -2354,6 +2437,7 @@ if(toggle_enhancedStick[2])  packed_toggles |= MASK_STICK_P3;
 if(autoCoverExit_mode[2])    packed_toggles |= MASK_COVEREXIT_MODE_P3;
 if(autoXSpam_mode[2])        packed_toggles |= MASK_SPAMMODE_P3;
 if(toggle_popShot[2])        packed_toggles |= MASK_POPSHOT_P3;
+if(toggle_shotgunRecoil[2]) packed_toggles |= MASK_SHOTGUN_P3;
 
 // Save the single packed integer
 // Add global AUTORUN_L3 bit
@@ -2366,7 +2450,23 @@ set_pvar(SPVAR_58, autoCoverExit_delay);
 set_pvar(SPVAR_59, autoCoverExit_duration);
 set_pvar(SPVAR_60, autoCoverExit_cooldown);
     set_pvar(SPVAR_61, enhancedStick_threshold);
-    set_pvar(SPVAR_64, popShot_hold_ms);
+    if(shotgun_recoil_vertical[0] < 0) shotgun_recoil_vertical[0] = 0;
+    if(shotgun_recoil_vertical[1] < 0) shotgun_recoil_vertical[1] = 0;
+    if(shotgun_recoil_vertical[2] < 0) shotgun_recoil_vertical[2] = 0;
+    if(shotgun_recoil_vertical[0] > 99) shotgun_recoil_vertical[0] = 99;
+    if(shotgun_recoil_vertical[1] > 99) shotgun_recoil_vertical[1] = 99;
+    if(shotgun_recoil_vertical[2] > 99) shotgun_recoil_vertical[2] = 99;
+    int shotgun_pack = 1;
+    shotgun_pack |= (shotgun_recoil_vertical[0] & 0xFF) << 1;
+    shotgun_pack |= (shotgun_recoil_vertical[1] & 0xFF) << 9;
+    shotgun_pack |= (shotgun_recoil_vertical[2] & 0xFF) << 17;
+    set_pvar(SPVAR_62, shotgun_pack);
+    if(popShot_hold_ms < 10) popShot_hold_ms = 10;
+    if(popShot_hold_ms > 500) popShot_hold_ms = 500;
+    if(shotgun_recoil_time_ms < 10) shotgun_recoil_time_ms = 10;
+    if(shotgun_recoil_time_ms > 500) shotgun_recoil_time_ms = 500;
+    int popshot_pack = ((shotgun_recoil_time_ms & 0x1FF) << 9) | (popShot_hold_ms & 0x1FF);
+    set_pvar(SPVAR_64, popshot_pack);
     set_pvar(SPVAR_63, autoReload_hold_ms);
 
 }


### PR DESCRIPTION
## Summary
- add a shotgun-only recoil pulse combo that triggers on blind-fire R2 presses without L2
- expose a per-profile toggle and vertical strength plus a global pulse duration in the Mod Menu
- persist the new settings alongside existing packed toggle/state storage

## Testing
- not run (Cronus Zen script)


------
https://chatgpt.com/codex/tasks/task_e_68e4a61c0e9c832881a2571693302049