### PR TITLE
Fix shotgun_pack declaration to resolve compiler error

### DIFF
--- a/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
+++ b/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
@@ -518,6 +518,7 @@ data(
     int migrated;    // One-time migration flag (SPVAR_62)
     int migrated_v2; // One-time migration v2 (SPVAR_63)
     int migrated_v3; // One-time migration v3 (SPVAR_63 stage 2)
+    int shotgun_pack; // Packed shotgun settings (SPVAR_62)
     int migration_flags;        // Migration flags bitmask (SPVAR_11)
     int migration_flags_original;
 


### PR DESCRIPTION
## Summary
- declare the packed shotgun settings variable so the init routine can access it without syntax errors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e4b87cbf5c8328a3111178228b8762