### PR TITLE
Reuse global shotgun_pack when saving recoil settings

### DIFF
--- a/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
+++ b/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
@@ -518,6 +518,7 @@ data(
     int migrated;    // One-time migration flag (SPVAR_62)
     int migrated_v2; // One-time migration v2 (SPVAR_63)
     int migrated_v3; // One-time migration v3 (SPVAR_63 stage 2)
+    int shotgun_pack; // Packed shotgun settings (SPVAR_62)
     int migration_flags;        // Migration flags bitmask (SPVAR_11)
     int migration_flags_original;
 
@@ -535,7 +536,7 @@ data(
  
 init{
 // One-time migration: set new default toggles and P3 rapidfire, then mark as migrated
-    int shotgun_pack = get_pvar(SPVAR_62, 0, 33554431, 0);
+    shotgun_pack = get_pvar(SPVAR_62, 0, 33554431, 0);
     migrated = shotgun_pack & 1;
     if(migrated == 0) {
         packed_toggles = (MASK_SPAM_P1 | MASK_COVEREXIT_P1 |
@@ -2537,7 +2538,7 @@ set_pvar(SPVAR_60, autoCoverExit_cooldown);
     if(shotgun_recoil_vertical[0] > 99) shotgun_recoil_vertical[0] = 99;
     if(shotgun_recoil_vertical[1] > 99) shotgun_recoil_vertical[1] = 99;
     if(shotgun_recoil_vertical[2] > 99) shotgun_recoil_vertical[2] = 99;
-    int shotgun_pack = 1;
+    shotgun_pack = 1;
     shotgun_pack |= (shotgun_recoil_vertical[0] & 0xFF) << 1;
     shotgun_pack |= (shotgun_recoil_vertical[1] & 0xFF) << 9;
     shotgun_pack |= (shotgun_recoil_vertical[2] & 0xFF) << 17;


### PR DESCRIPTION
## Summary
- reuse the global shotgun_pack variable when encoding shotgun recoil settings to avoid redeclaration errors

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e4b87cbf5c8328a3111178228b8762