### PR TITLE
Fix PERFECTRELOAD combo wait placement

### DIFF
--- a/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
+++ b/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
@@ -1867,12 +1867,12 @@ combo SAVE {
 
 // 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 
 
-		combo PERFECTRELOAD {
-	    wait(perfectreload_wait_ms);
-	    set_val(PS4_R1, 100);
-	    wait(40);
-	    set_val(PS4_R1, 0);
-	    }
+combo PERFECTRELOAD {
+        wait(perfectreload_wait_ms);
+        set_val(PS4_R1, 100);
+        wait(40);
+        set_val(PS4_R1, 0);
+}
 
 // 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 〜 
  


### PR DESCRIPTION
## Summary
- normalize the PERFECTRELOAD combo definition so wait() stays at the top level and braces are aligned

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5c4a08df08328b3c7a77e465c7c20