### PR TITLE
Expand manual tap gap range and default profile 3 rapid fire value

### DIFF
--- a/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
+++ b/gears_of_war_5_zen_mod_menu_3_profiles_9.18.gpc
@@ -548,6 +548,7 @@ init{
                           MASK_SPAM_P3 | MASK_COVEREXIT_P3);
         set_pvar(SPVAR_56, packed_toggles);
         set_pvar(SPVAR_33, 1); // Rapid Fire default ON for Profile 3
+        set_pvar(SPVAR_45, 25); // Rapid Fire value max for Profile 3
         shotgun_pack = 1;
         set_pvar(SPVAR_62, shotgun_pack); // Migration complete
         migrated = 1;
@@ -556,7 +557,7 @@ init{
     // One-time migration v2: bump Spam Speed default from 40 -> 80 only if still at old default
     migrated_v2 = get_pvar(SPVAR_63, 0, 1, 0);
     if(migrated_v2 == 0) {
-        spam_pack = get_pvar(SPVAR_57, 0, 131071, 0);
+        spam_pack = get_pvar(SPVAR_57, 0, 2097151, 0);
         legacy_speed = 0;
         if(spam_pack == 0) {
             legacy_speed = 40;
@@ -640,7 +641,7 @@ init{
 	// Toggles                                                  // Values
 	toggle_antirecoil[2] 		= get_pvar(SPVAR_32, 0, 1, 0 );        antirecoil_vertical[2]   = get_pvar(SPVAR_43, -99, 99, 0);         
 		toggle_rapidfire[2]  		= get_pvar(SPVAR_33, 0, 1, 1 );        antirecoil_horizontal[2] = get_pvar(SPVAR_44, -99, 99, 0);
-	toggle_burstfire[2]  		= get_pvar(SPVAR_34, 0, 1, 0 );        rate_of_fire[2]          = get_pvar(SPVAR_45,   0, 25, 0);
+	toggle_burstfire[2]  		= get_pvar(SPVAR_34, 0, 1, 0 );        rate_of_fire[2]          = get_pvar(SPVAR_45,   0, 25, 25);
 		toggle_aimassist[2]  		= get_pvar(SPVAR_35, 0, 1, 0 );        perfectreload_time [2] 	= get_pvar(SPVAR_46, 0, 5000, 480);	
 	toggle_strafeShot[2] 		= get_pvar(SPVAR_36, 0, 1, 0 );
 	toggle_customSense[2] 		= get_pvar(SPVAR_37, 0, 1, 0 );
@@ -747,7 +748,7 @@ init{
     if(packed_toggles & MASK_AUTORUN_L3) { autorun_l3_toggle_enabled = TRUE; } else { autorun_l3_toggle_enabled = FALSE; }
 
     // Load Global Values for New Features (using the available SPVAR slots)
-    spam_pack = get_pvar(SPVAR_57, 0, 131071, (100 << 9) | 80);
+    spam_pack = get_pvar(SPVAR_57, 0, 2097151, (100 << 9) | 80);
     if(spam_pack <= 200) {
         autoXSpam_speed = spam_pack;
         if(autoXSpam_speed < 10 || autoXSpam_speed > 200) {
@@ -758,12 +759,12 @@ init{
         set_pvar(SPVAR_57, spam_pack);
     } else {
         autoXSpam_speed = spam_pack & 0x1FF;
-        manualL1_doubletap_delay = (spam_pack >> 9) & 0x1FF;
+        manualL1_doubletap_delay = (spam_pack >> 9) & 0x0FFF;
     }
     if(autoXSpam_speed < 10) autoXSpam_speed = 10;
     if(autoXSpam_speed > 200) autoXSpam_speed = 200;
     if(manualL1_doubletap_delay < 20) manualL1_doubletap_delay = 20;
-    if(manualL1_doubletap_delay > 500) manualL1_doubletap_delay = 500;
+    if(manualL1_doubletap_delay > 2000) manualL1_doubletap_delay = 2000;
     autoCoverExit_delay      = get_pvar(SPVAR_58, 50, 500, 200);
     autoCoverExit_duration   = get_pvar(SPVAR_59, 50, 500, 150);
     autoCoverExit_cooldown   = get_pvar(SPVAR_60, 100, 2000, 500);
@@ -1022,7 +1023,7 @@ if(!KillSwitch)
                 customSense_time  = edit_val( 8 , customSense_time  , 0 , 327  , 10 , 100  );
                 autoXSpam_mode[profile_idx] = edit_val( 10, autoXSpam_mode[profile_idx], 0, 1, 1, 1); // Mode is 0 or 1
                 autoXSpam_speed             = edit_val( 11, autoXSpam_speed, 10, 200, 10, 50);
-                manualL1_doubletap_delay    = edit_val( 22, manualL1_doubletap_delay, 20, 500, 5, 25);
+                manualL1_doubletap_delay    = edit_val( 22, manualL1_doubletap_delay, 20, 2000, 5, 25);
                 autoCoverExit_delay         = edit_val( 12, autoCoverExit_delay, 50, 500, 10, 50);
                 autoCoverExit_duration      = edit_val( 13, autoCoverExit_duration, 50, 500, 10, 50);
                 autoCoverExit_cooldown      = edit_val( 14, autoCoverExit_cooldown, 100, 2000, 50, 200);
@@ -2537,7 +2538,7 @@ if(autorun_l3_toggle_enabled) packed_toggles |= MASK_AUTORUN_L3;
 set_pvar(SPVAR_56, packed_toggles);
 
 // Save Global Values for New Features
-spam_pack_save = (manualL1_doubletap_delay << 9) | autoXSpam_speed;
+spam_pack_save = ((manualL1_doubletap_delay & 0x0FFF) << 9) | (autoXSpam_speed & 0x01FF);
 set_pvar(SPVAR_57, spam_pack_save);
 set_pvar(SPVAR_58, autoCoverExit_delay);
 set_pvar(SPVAR_59, autoCoverExit_duration);


### PR DESCRIPTION
## Summary
- raise the Manual L1 double tap gap edit range and clamps to 2000 ms while updating SPVAR_57 packing to handle 12-bit values
- default Profile 3 rapid fire value to the max and seed it during first-run migration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7347a69308328becda1f1af9cdd6c